### PR TITLE
Make `workerUrl` fetch bundler-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.15] - 2026-02-20
+
+### Added
+- **`workerUrl` option for `createRuntime()` and `WorkerRuntime`**: Pass a custom URL for the runtime Web Worker script. This is required when using almostnode with Turbopack or Webpack, which statically resolve `new URL(..., import.meta.url)` at build time and fail on server-relative asset paths from the almostnode dist. When `workerUrl` is omitted, the existing Vite-compatible behavior is preserved.
+- **`getWorkerContent()` and `getWorkerPath()` in `almostnode/next`**: Helpers to read the built runtime worker script from the almostnode package, analogous to the existing `getServiceWorkerContent()` / `getServiceWorkerPath()`. Use these to serve the worker from a Next.js API route and pass the route URL as `workerUrl`.
+- **Stable worker filename**: The runtime worker is now built as `dist/assets/runtime-worker.js` (no content hash) so it can be located and served reliably by consuming projects.
+
+### Changed
+- Worker build output now uses stable filenames (`entryFileNames: '[name].js'`) instead of hashed names, making the file locatable without a glob.
+
 ## [0.2.14] - 2026-02-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -353,6 +353,44 @@ await bridge.initServiceWorker({ swUrl: '/api/__sw__' });
 |--------|-------------|
 | `getServiceWorkerContent()` | Returns the service worker file content as a string |
 | `getServiceWorkerPath()` | Returns the absolute path to the service worker file |
+| `getWorkerContent()` | Returns the runtime Web Worker script as a string (for Turbopack/Webpack) |
+| `getWorkerPath()` | Returns the absolute path to the runtime Web Worker script |
+
+#### Using `WorkerRuntime` with Turbopack or Webpack
+
+If you use `useWorker: true` with `createRuntime()`, almostnode defaults to resolving the
+worker script via `new URL(..., import.meta.url)`. **Turbopack and Webpack statically
+analyze this pattern at build time** and fail when the path is a server-relative
+`/assets/...` URL from the almostnode dist.
+
+To fix this, serve the worker file from a Next.js API route and pass its URL as `workerUrl`:
+
+```typescript
+// app/api/almostnode-worker/route.ts
+import { getWorkerContent } from 'almostnode/next';
+
+export async function GET() {
+  return new Response(getWorkerContent(), {
+    headers: {
+      'Content-Type': 'application/javascript',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}
+```
+
+Then pass `workerUrl` when creating the runtime:
+
+```typescript
+// In your client component
+import { createRuntime } from 'almostnode';
+
+const runtime = await createRuntime(vfs, {
+  dangerouslyAllowSameOrigin: true,
+  useWorker: true,
+  workerUrl: '/api/almostnode-worker',
+});
+```
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "almostnode",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "almostnode",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "almostnode",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Node.js in your browser. Just like that.",
   "type": "module",
   "license": "MIT",

--- a/src/create-runtime.ts
+++ b/src/create-runtime.ts
@@ -84,7 +84,7 @@ export async function createRuntime(
   vfs: VirtualFS,
   options: CreateRuntimeOptions = {}
 ): Promise<IRuntime> {
-  const { sandbox, dangerouslyAllowSameOrigin, useWorker = false, ...runtimeOptions } = options;
+  const { sandbox, dangerouslyAllowSameOrigin, useWorker = false, workerUrl, ...runtimeOptions } = options;
 
   // SECURE: Cross-origin sandbox mode
   if (sandbox) {
@@ -124,7 +124,7 @@ export async function createRuntime(
 
   if (shouldUseWorker) {
     console.log('[createRuntime] Creating WorkerRuntime (same-origin, thread-isolated)');
-    const workerRuntime = new WorkerRuntime(vfs, runtimeOptions);
+    const workerRuntime = new WorkerRuntime(vfs, { ...runtimeOptions, workerUrl });
     // Wait for worker to be ready by executing a simple command
     await workerRuntime.execute('/* worker ready check */', '/__worker_init__.js');
     return workerRuntime;

--- a/src/runtime-interface.ts
+++ b/src/runtime-interface.ts
@@ -87,6 +87,36 @@ export interface CreateRuntimeOptions extends IRuntimeOptions {
    * They still have access to IndexedDB and can make network requests.
    */
   useWorker?: boolean | 'auto';
+
+  /**
+   * URL of the pre-built almostnode runtime worker script.
+   *
+   * By default, WorkerRuntime uses `new URL('./worker/runtime-worker.ts', import.meta.url)`
+   * which Vite resolves at build time. This works fine with Vite, but breaks with Turbopack
+   * and Webpack because they try to statically resolve the asset path at build time and fail
+   * when the path is a server-relative `/assets/...` URL from the almostnode dist.
+   *
+   * To fix this, serve the worker file yourself and pass its URL here:
+   *
+   * @example Next.js (App Router)
+   * ```typescript
+   * // app/api/almostnode-worker/route.ts
+   * import { getWorkerContent } from 'almostnode/next';
+   * export async function GET() {
+   *   return new Response(getWorkerContent(), {
+   *     headers: { 'Content-Type': 'application/javascript' },
+   *   });
+   * }
+   *
+   * // In your component:
+   * const runtime = await createRuntime(vfs, {
+   *   dangerouslyAllowSameOrigin: true,
+   *   useWorker: true,
+   *   workerUrl: '/api/almostnode-worker',
+   * });
+   * ```
+   */
+  workerUrl?: string | URL;
 }
 
 /**

--- a/tests/next-plugin.test.ts
+++ b/tests/next-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getServiceWorkerContent, getServiceWorkerPath } from '../src/next-plugin';
+import { getServiceWorkerContent, getServiceWorkerPath, getWorkerContent, getWorkerPath } from '../src/next-plugin';
 import * as fs from 'fs';
 
 describe('next-plugin', () => {
@@ -33,6 +33,34 @@ describe('next-plugin', () => {
       const content = getServiceWorkerContent();
       const swPath = getServiceWorkerPath();
       const fileContent = fs.readFileSync(swPath, 'utf-8');
+      expect(content).toBe(fileContent);
+    });
+  });
+
+  describe('getWorkerPath', () => {
+    it('should return a valid file path', () => {
+      const workerPath = getWorkerPath();
+      expect(typeof workerPath).toBe('string');
+      expect(workerPath).toContain('runtime-worker.js');
+    });
+
+    it('should return a path that exists', () => {
+      const workerPath = getWorkerPath();
+      expect(fs.existsSync(workerPath)).toBe(true);
+    });
+  });
+
+  describe('getWorkerContent', () => {
+    it('should return worker content as a string', () => {
+      const content = getWorkerContent();
+      expect(typeof content).toBe('string');
+      expect(content.length).toBeGreaterThan(0);
+    });
+
+    it('should match the file content from getWorkerPath', () => {
+      const content = getWorkerContent();
+      const workerPath = getWorkerPath();
+      const fileContent = fs.readFileSync(workerPath, 'utf-8');
       expect(content).toBe(fileContent);
     });
   });

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -1,24 +1,30 @@
-import { defineConfig } from 'vite';
-import { resolve } from 'path';
-import wasm from 'vite-plugin-wasm';
-
+import { defineConfig } from "vite";
+import { resolve } from "path";
+import wasm from "vite-plugin-wasm";
 
 export default defineConfig({
   plugins: [
     wasm(),
     {
-      name: 'browser-shims',
-      enforce: 'pre',
+      name: "browser-shims",
+      enforce: "pre",
       resolveId(source) {
-        if (source === 'node:zlib' || source === 'zlib') {
-          return resolve(__dirname, 'src/shims/zlib.ts');
+        if (source === "node:zlib" || source === "zlib") {
+          return resolve(__dirname, "src/shims/zlib.ts");
         }
-        if (source === 'brotli-wasm/pkg.web/brotli_wasm.js') {
-          return resolve(__dirname, 'node_modules/brotli-wasm/pkg.web/brotli_wasm.js');
+        if (source === "brotli-wasm/pkg.web/brotli_wasm.js") {
+          return resolve(
+            __dirname,
+            "node_modules/brotli-wasm/pkg.web/brotli_wasm.js",
+          );
         }
-        if (source === 'brotli-wasm/pkg.web/brotli_wasm_bg.wasm?url') {
+        if (source === "brotli-wasm/pkg.web/brotli_wasm_bg.wasm?url") {
           return {
-            id: resolve(__dirname, 'node_modules/brotli-wasm/pkg.web/brotli_wasm_bg.wasm') + '?url',
+            id:
+              resolve(
+                __dirname,
+                "node_modules/brotli-wasm/pkg.web/brotli_wasm_bg.wasm",
+              ) + "?url",
             external: false,
           };
         }
@@ -27,65 +33,67 @@ export default defineConfig({
     },
   ],
   define: {
-    'process.env': {},
-    global: 'globalThis',
+    "process.env": {},
+    global: "globalThis",
   },
   resolve: {
     alias: {
-      'node:zlib': resolve(__dirname, 'src/shims/zlib.ts'),
-      'zlib': resolve(__dirname, 'src/shims/zlib.ts'),
-      'buffer': 'buffer',
-      'process': 'process/browser',
+      "node:zlib": resolve(__dirname, "src/shims/zlib.ts"),
+      zlib: resolve(__dirname, "src/shims/zlib.ts"),
+      buffer: "buffer",
+      process: "process/browser",
     },
   },
   worker: {
-    format: 'es',
-    plugins: () => [
-      wasm(),
-    ],
+    format: "es",
+    plugins: () => [wasm()],
     rollupOptions: {
       output: {
         inlineDynamicImports: true,
+        entryFileNames: "[name].js",
+        chunkFileNames: "[name].js",
+        assetFileNames: "[name][extname]",
       },
     },
   },
   build: {
     lib: {
       entry: {
-        index: resolve(__dirname, 'src/index.ts'),
-        'vite-plugin': resolve(__dirname, 'src/vite-plugin.ts'),
-        'next-plugin': resolve(__dirname, 'src/next-plugin.ts'),
+        index: resolve(__dirname, "src/index.ts"),
+        "vite-plugin": resolve(__dirname, "src/vite-plugin.ts"),
+        "next-plugin": resolve(__dirname, "src/next-plugin.ts"),
       },
-      name: 'JustNode',
-      formats: ['es', 'cjs'],
-      fileName: (format, entryName) => `${entryName}.${format === 'es' ? 'mjs' : 'cjs'}`,
+      name: "JustNode",
+      formats: ["es", "cjs"],
+      fileName: (format, entryName) =>
+        `${entryName}.${format === "es" ? "mjs" : "cjs"}`,
     },
     rollupOptions: {
       external: [
-        'brotli-wasm',
-        'pako',
-        'comlink',
-        'just-bash',
-        'resolve.exports',
-        'brotli',
+        "brotli-wasm",
+        "pako",
+        "comlink",
+        "just-bash",
+        "resolve.exports",
+        "brotli",
         // Node.js built-ins for vite-plugin
-        'fs',
-        'path',
-        'url',
-        'vite',
+        "fs",
+        "path",
+        "url",
+        "vite",
       ],
       output: {
         globals: {
-          'brotli-wasm': 'brotliWasm',
-          'pako': 'pako',
-          'comlink': 'Comlink',
-          'just-bash': 'justBash',
-          'resolve.exports': 'resolveExports',
+          "brotli-wasm": "brotliWasm",
+          pako: "pako",
+          comlink: "Comlink",
+          "just-bash": "justBash",
+          "resolve.exports": "resolveExports",
         },
       },
     },
     sourcemap: true,
     minify: false,
   },
-  assetsInclude: ['**/*.wasm'],
+  assetsInclude: ["**/*.wasm"],
 });

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -1,30 +1,24 @@
-import { defineConfig } from "vite";
-import { resolve } from "path";
-import wasm from "vite-plugin-wasm";
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import wasm from 'vite-plugin-wasm';
+
 
 export default defineConfig({
   plugins: [
     wasm(),
     {
-      name: "browser-shims",
-      enforce: "pre",
+      name: 'browser-shims',
+      enforce: 'pre',
       resolveId(source) {
-        if (source === "node:zlib" || source === "zlib") {
-          return resolve(__dirname, "src/shims/zlib.ts");
+        if (source === 'node:zlib' || source === 'zlib') {
+          return resolve(__dirname, 'src/shims/zlib.ts');
         }
-        if (source === "brotli-wasm/pkg.web/brotli_wasm.js") {
-          return resolve(
-            __dirname,
-            "node_modules/brotli-wasm/pkg.web/brotli_wasm.js",
-          );
+        if (source === 'brotli-wasm/pkg.web/brotli_wasm.js') {
+          return resolve(__dirname, 'node_modules/brotli-wasm/pkg.web/brotli_wasm.js');
         }
-        if (source === "brotli-wasm/pkg.web/brotli_wasm_bg.wasm?url") {
+        if (source === 'brotli-wasm/pkg.web/brotli_wasm_bg.wasm?url') {
           return {
-            id:
-              resolve(
-                __dirname,
-                "node_modules/brotli-wasm/pkg.web/brotli_wasm_bg.wasm",
-              ) + "?url",
+            id: resolve(__dirname, 'node_modules/brotli-wasm/pkg.web/brotli_wasm_bg.wasm') + '?url',
             external: false,
           };
         }
@@ -33,69 +27,70 @@ export default defineConfig({
     },
   ],
   define: {
-    "process.env": {},
-    global: "globalThis",
+    'process.env': {},
+    global: 'globalThis',
   },
   resolve: {
     alias: {
-      "node:zlib": resolve(__dirname, "src/shims/zlib.ts"),
-      zlib: resolve(__dirname, "src/shims/zlib.ts"),
-      buffer: "buffer",
-      process: "process/browser",
+      'node:zlib': resolve(__dirname, 'src/shims/zlib.ts'),
+      'zlib': resolve(__dirname, 'src/shims/zlib.ts'),
+      'buffer': 'buffer',
+      'process': 'process/browser',
     },
   },
   worker: {
-    format: "es",
-    plugins: () => [wasm()],
+    format: 'es',
+    plugins: () => [
+      wasm(),
+    ],
     rollupOptions: {
       output: {
         inlineDynamicImports: true,
         // Stable filename (no hash) so next-plugin.ts can locate the worker
         // without a glob and consumers can serve it from a predictable path.
-        entryFileNames: "[name].js",
-        chunkFileNames: "[name].js",
-        assetFileNames: "[name][extname]",
+        entryFileNames: '[name].js',
+        chunkFileNames: '[name].js',
+        assetFileNames: '[name][extname]',
       },
     },
   },
   build: {
     lib: {
       entry: {
-        index: resolve(__dirname, "src/index.ts"),
-        "vite-plugin": resolve(__dirname, "src/vite-plugin.ts"),
-        "next-plugin": resolve(__dirname, "src/next-plugin.ts"),
+        index: resolve(__dirname, 'src/index.ts'),
+        'vite-plugin': resolve(__dirname, 'src/vite-plugin.ts'),
+        'next-plugin': resolve(__dirname, 'src/next-plugin.ts'),
       },
-      name: "JustNode",
-      formats: ["es", "cjs"],
-      fileName: (format, entryName) =>
-        `${entryName}.${format === "es" ? "mjs" : "cjs"}`,
+      name: 'JustNode',
+      formats: ['es', 'cjs'],
+      fileName: (format, entryName) => `${entryName}.${format === 'es' ? 'mjs' : 'cjs'}`,
     },
     rollupOptions: {
       external: [
-        "brotli-wasm",
-        "pako",
-        "comlink",
-        "just-bash",
-        "resolve.exports",
-        "brotli",
+        'brotli-wasm',
+        'pako',
+        'comlink',
+        'just-bash',
+        'resolve.exports',
+        'brotli',
         // Node.js built-ins for vite-plugin
-        "fs",
-        "path",
-        "url",
-        "vite",
+        'fs',
+        'path',
+        'url',
+        'vite',
       ],
       output: {
         globals: {
-          "brotli-wasm": "brotliWasm",
-          pako: "pako",
-          comlink: "Comlink",
-          "just-bash": "justBash",
-          "resolve.exports": "resolveExports",
+          'brotli-wasm': 'brotliWasm',
+          'pako': 'pako',
+          'comlink': 'Comlink',
+          'just-bash': 'justBash',
+          'resolve.exports': 'resolveExports',
         },
       },
     },
     sourcemap: true,
     minify: false,
   },
-  assetsInclude: ["**/*.wasm"],
+  assetsInclude: ['**/*.wasm'],
 });

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -50,6 +50,8 @@ export default defineConfig({
     rollupOptions: {
       output: {
         inlineDynamicImports: true,
+        // Stable filename (no hash) so next-plugin.ts can locate the worker
+        // without a glob and consumers can serve it from a predictable path.
         entryFileNames: "[name].js",
         chunkFileNames: "[name].js",
         assetFileNames: "[name][extname]",


### PR DESCRIPTION
When almostnode's library is built by Vite, `new URL('./worker/runtime-worker.ts', import.meta.url)` in `WorkerRuntime` is transformed into `new Worker(new URL("/assets/runtime-worker-<hash>.js", import.meta.url), ...)` in `dist/index.mjs`. 

Turbopack (and Webpack) statically analyze `new URL(..., import.meta.url)` at build time and fail when the path is a server-relative `/assets/...` URL — they can't find the file in the consuming project's asset pipeline.


### The fix in practice

Before (breaks Turbopack/Webpack — they try to resolve the asset at build time):
```ts
// consumer code
const runtime = await createRuntime(vfs, { useWorker: true, dangerouslyAllowSameOrigin: true });
//                                         ^ internally uses new URL("/assets/runtime-worker-HASH.js", import.meta.url)
//                                           Turbopack: __turbopack_context__.x is not a function
```

After (works with any bundler):
```ts
// app/api/almostnode-worker/route.ts
import { getWorkerContent } from 'almostnode/next';
export async function GET() {
  return new Response(getWorkerContent(), { headers: { 'Content-Type': 'application/javascript' } });
}

// In your component
const runtime = await createRuntime(vfs, {
  useWorker: true,
  dangerouslyAllowSameOrigin: true,
  workerUrl: '/api/almostnode-worker',  // ← bypasses the static analysis entirely
});
```

The default behavior (no `workerUrl`) is unchanged — Vite users are unaffected.